### PR TITLE
Use the same os_dep_getResourceUsage on all *NIX machines, not just Linux

### DIFF
--- a/unix.go
+++ b/unix.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build !windows
 
 package ergo
 


### PR DESCRIPTION
With this diff I can build / execute `examples/simple/GenServer.go`.