### PR TITLE
fixes #45

### DIFF
--- a/lib/tools.go
+++ b/lib/tools.go
@@ -51,6 +51,9 @@ func TakeTimer() *time.Timer {
 }
 
 func ReleaseTimer(t *time.Timer) {
+	if !t.Stop() {
+		<-t.C
+	}
 	timers.Put(t)
 }
 


### PR DESCRIPTION
There is a corner case when the timer gets back too fast and takes for the next run, so the resetting doesn't affect it. We should stop it explicitly by calling the Stop() method. More information is here https://golang.org/pkg/time/#Timer.Reset