### PR TITLE
Fixcontextleaks

### DIFF
--- a/node.go
+++ b/node.go
@@ -83,10 +83,6 @@ const (
 	defaultRecvQueueLength   int = 100
 	defaultFragmentationUnit     = 65000
 
-	versionOTP        int = 22
-	versionERTSprefix     = "ergo"
-	version               = "1.1.0"
-
 	// TLSmodeDisabled no TLS encryption
 	TLSmodeDisabled TLSmodeType = ""
 	// TLSmodeAuto generate self-signed certificate

--- a/process.go
+++ b/process.go
@@ -206,6 +206,7 @@ func (p *Process) SendAfter(to interface{}, message etf.Term, after time.Duratio
 		// to prevent of timer leaks due to its not GCed until the timer fires
 		timer := time.NewTimer(after)
 		defer timer.Stop()
+		defer cancel()
 
 		select {
 		case <-ctx.Done():

--- a/registrar.go
+++ b/registrar.go
@@ -175,6 +175,8 @@ func (r *registrar) UnregisterProcess(pid etf.Pid) {
 			}
 		}
 		r.mutexProcesses.Unlock()
+		// invoke cancel context to prevent memory leaks
+		p.Kill()
 		return
 	}
 	r.mutexProcesses.Unlock()

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package ergo
 
 const (
-	versionOTP        int = 24
+	versionOTP        int = 22
 	versionERTSprefix     = "ergo"
 	version               = "1.3.0"
 )

--- a/version.go
+++ b/version.go
@@ -1,0 +1,7 @@
+package ergo
+
+const (
+	versionOTP        int = 24
+	versionERTSprefix     = "ergo"
+	version               = "1.3.0"
+)

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package ergo
 const (
 	versionOTP        int = 22
 	versionERTSprefix     = "ergo"
-	version               = "1.3.0"
+	version               = "1.2.4"
 )


### PR DESCRIPTION
- Created Context should be canceled explicitly to prevent memory leaks.
- versions are moved to the separated file
- bumped version
