### PR TITLE
Fix Atom Cache race conditioned issue

### DIFF
--- a/types.go
+++ b/types.go
@@ -2,8 +2,9 @@ package ergo
 
 import (
 	"fmt"
-	"github.com/halturin/ergo/etf"
 	"sync"
+
+	"github.com/halturin/ergo/etf"
 )
 
 var (


### PR DESCRIPTION
Case:  we got two packets like MONITOR, REG_SEND (which is usual for the regular gen_server:call from the Erlang). The first packet (MONITOR) has new atom cache entries that should be used in the next packet (REG_SEND). But sometimes, doing handle REG_SEND packet, the atom cache still has no entries due to processing of the MONITOR packet is doing on another goroutine and hasn't finished yet.

So, this PR is fixing this problem.
