### PR TITLE
add recover handler in the etf encoder

### DIFF
--- a/etf/encode.go
+++ b/etf/encode.go
@@ -23,7 +23,7 @@ func Encode(term Term, b *lib.Buffer,
 	writerAtomCache map[Atom]CacheItem,
 	encodingAtomCache *ListAtomCache) (retErr error) {
 	defer func() {
-		// We should catch any panic happend during encoding the raw data.
+		// We should catch any panic happend during encoding Golang types.
 		if r := recover(); r != nil {
 			retErr = fmt.Errorf("%v", r)
 		}

--- a/etf/encode.go
+++ b/etf/encode.go
@@ -3,10 +3,11 @@ package etf
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/halturin/ergo/lib"
 	"math"
 	"math/big"
 	"reflect"
+
+	"github.com/halturin/ergo/lib"
 )
 
 var (
@@ -20,7 +21,13 @@ var (
 func Encode(term Term, b *lib.Buffer,
 	linkAtomCache *AtomCache,
 	writerAtomCache map[Atom]CacheItem,
-	encodingAtomCache *ListAtomCache) error {
+	encodingAtomCache *ListAtomCache) (retErr error) {
+	defer func() {
+		// We should catch any panic happend during encoding the raw data.
+		if r := recover(); r != nil {
+			retErr = fmt.Errorf("%v", r)
+		}
+	}()
 
 	var stack, child *stackElement
 


### PR DESCRIPTION
ETF decoder already has a "recover" wrapper. We should wrap it the same way in the encoder.

Fixes #63 