### PR TITLE
add freebsd getrusage(2) syscall

### DIFF
--- a/freebsd.go
+++ b/freebsd.go
@@ -1,0 +1,17 @@
+// +build freebsd
+
+package ergo
+
+import (
+	"syscall"
+)
+
+func os_dep_getResourceUsage() (int64, int64) {
+	var usage syscall.Rusage
+	var utime, stime int64
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &usage); err == nil {
+		utime = usage.Utime.Sec*1000000000 + usage.Utime.Nano()
+		stime = usage.Stime.Sec*1000000000 + usage.Stime.Nano()
+	}
+	return utime, stime
+}


### PR DESCRIPTION
see [getrusage(2)](https://www.freebsd.org/cgi/man.cgi?query=getrusage&sektion=2) & tested on both amd64 and arm64.

FWIW some tests, all without SMT, on various FreeBSD versions & hardware.

- intel xeon 8 cores, FreeBSD 13.0-RELEASE

```
$ sysctl hw.model
hw.model: Intel(R) Xeon(R) CPU E5-2667 v4 @ 3.20GHz
$ go test -bench=NodeSequential -run=100 -benchtime=10s
goos: freebsd
goarch: amd64
pkg: github.com/halturin/ergo
cpu: Intel(R) Xeon(R) CPU E5-2667 v4 @ 3.20GHz
BenchmarkNodeSequential/number-8      	
  250360	    117424 ns/op
BenchmarkNodeSequential/string-8      	  121123	    110564 ns/op
BenchmarkNodeSequential/tuple_(PID)-8 	  189829	    122262 ns/op
BenchmarkNodeSequential/binary_1MB-8  	    1716	   7349980 ns/op
BenchmarkNodeSequentialSingleNode/number-8         	  752913	     21122 ns/op
BenchmarkNodeSequentialSingleNode/string-8         	  561376	     20437 ns/op
BenchmarkNodeSequentialSingleNode/tuple_(PID)-8    	  607036	     20287 ns/op
BenchmarkNodeSequentialSingleNode/binary_1MB-8     	  559360	     21223 ns/op
PASS
```

- ampere altra, 2 cores, FreeBSD 14.0-CURRENT (lots of debugging enabled)

```
$ sysctl hw.model
hw.model: ARM Neoverse-N1 r3p1
$ go test -bench=NodeSequential -run=100 -benchtime=10s

goos: freebsd
goarch: arm64
pkg: github.com/halturin/ergo
BenchmarkNodeSequential/number-2          134977             84636 ns/op
BenchmarkNodeSequential/string-2          142143             84559 ns/op
BenchmarkNodeSequential/tuple_(PID)-2     136266             92182 ns/op
BenchmarkNodeSequential/binary_1MB-2        4213           2811246 ns/op
BenchmarkNodeSequentialSingleNode/number-2               1448876              8257 ns/op
BenchmarkNodeSequentialSingleNode/string-2               1452616              8232 ns/op
BenchmarkNodeSequentialSingleNode/tuple_(PID)-2          1463661             13837 ns/op
BenchmarkNodeSequentialSingleNode/binary_1MB-2           1476330              8179 ns/op
PASS
ok      github.com/halturin/ergo        148.172s
```

- ampere emag 32 cores, FreeBSD 14.0-CURRENT (lots of debugging enabled)

```
$ sysctl hw.model
hw.model: APM eMAG 8180 r3p2
$ go test -bench=NodeSequential -run=100 -benchtime=10s

goos: freebsd
goarch: arm64
pkg: github.com/halturin/ergo
BenchmarkNodeSequential/number-32                  77108            153407 ns/op
BenchmarkNodeSequential/string-32                  78672            153402 ns/op
BenchmarkNodeSequential/tuple_(PID)-32             75832            157856 ns/op
BenchmarkNodeSequential/binary_1MB-32               3616           3112661 ns/op
BenchmarkNodeSequentialSingleNode/number-32               718996             16724 ns/op
BenchmarkNodeSequentialSingleNode/string-32               720394             16715 ns/op
BenchmarkNodeSequentialSingleNode/tuple_(PID)-32          727790             16730 ns/op
BenchmarkNodeSequentialSingleNode/binary_1MB-32           717544             16696 ns/op
PASS
ok      github.com/halturin/ergo        101.136s                                                                                                                                                                                                                          
```


- ampere emag 32 cores, FreeBSD 13.0-RELEASE

```
$ sysctl hw.model
hw.model: APM eMAG 8180 r3p2
$ go test -bench=NodeSequential -run=100 -benchtime=10s


goos: freebsd
goarch: arm64
pkg: github.com/halturin/ergo
BenchmarkNodeSequential/number-32                  77108            153407 ns/op
BenchmarkNodeSequential/string-32                  78672            153402 ns/op
BenchmarkNodeSequential/tuple_(PID)-32             75832            157856 ns/op
BenchmarkNodeSequential/binary_1MB-32               3616           3112661 ns/op
BenchmarkNodeSequentialSingleNode/number-32               718996             16724 ns/op
BenchmarkNodeSequentialSingleNode/string-32               720394             16715 ns/op
BenchmarkNodeSequentialSingleNode/tuple_(PID)-32          727790             16730 ns/op
BenchmarkNodeSequentialSingleNode/binary_1MB-32           717544             16696 ns/op
PASS
ok      github.com/halturin/ergo        101.136s                                                                                                                                                                                                                          
```
